### PR TITLE
Adjust provisioning to allow for use with RabbitMQ

### DIFF
--- a/priv/provision.html
+++ b/priv/provision.html
@@ -370,7 +370,6 @@
             type="text"
             name="gateway_user"
             placeholder="Enter MQTT username"
-            required
             />
         </div>
 
@@ -380,7 +379,6 @@
             type="password"
             name="gateway_pass"
             placeholder="Enter MQTT password"
-            required
             />
         </div>
 

--- a/src/c3card_provision.erl
+++ b/src/c3card_provision.erl
@@ -86,8 +86,8 @@ handle_req("POST", [], Conn) ->
     Pass = proplists:get_value("pass", Params),
     EnableMQTT = proplists:get_value("gateway_enabled", Params, "off"),
     Gateway = proplists:get_value("gateway", Params),
-    User = proplists:get_value("gateway_user", Params),
-    Password = proplists:get_value("gateway_pass", Params),
+    User = proplists:get_value("gateway_user", Params, ""),
+    Password = proplists:get_value("gateway_pass", Params, ""),
     DeviceName = proplists:get_value("device_name", Params),
 
     ok = save_config(


### PR DESCRIPTION
Slight changes to the provisioning to allow login to RabbitMQ MQTT broker. With RabbitMQ the username and password must be submitted as part of the URL: `mqtt://user:password@broker.domain`.